### PR TITLE
Update template docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,6 @@ This document explains the processes and practices recommended for contributing 
 When contributing, you must abide by the
 [Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct).
 
-## Canonical contributor agreement
-
-Canonical welcomes contributions to the <charm-name> charm. Please check out our
-[contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the solution.
-
 ## Releases and versions
 
 This project uses [semantic versioning](https://semver.org/).
@@ -91,15 +86,23 @@ your pull request must provide the following details:
 ### Signing commits
 
 To improve contribution tracking,
-we use the developer certificate of origin
-([DCO 1.1](<https://developercertificate.org/))
-and require a "sign-off" for any changes going into each branch.
+we use the [Canonical contributor license agreement](https://assets.ubuntu.com/v1/ff2478d1-Canonical-HA-CLA-ANY-I_v1.2.pdf)
+(CLA) as a legal sign-off, and we require all commits to have verified signatures.
 
-The sign-off is a simple line at the end of the commit message
-certifying that you wrote it
+#### Canonical contributor agreement
+
+Canonical welcomes contributions to the Discourse charm. Please check out our
+[contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the solution.
+
+The CLA sign-off is simple line at the
+end of the commit message certifying that you wrote it
 or have the right to commit it as an open-source contribution.
 
-To sign off on a commit, follow the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+#### Verified signatures on commits
+
+All commits in a pull request must have cryptographic (verified) signatures.
+To add signatures on your commits, follow the
+[GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ## Develop
 
@@ -112,18 +115,13 @@ The code for this charm can be downloaded as follows:
 git clone https://github.com/canonical/<charm-name>
 ```
 
-You can use the environments created by `tox` for development:
-
-```shell
-tox --notest -e unit
-source .tox/unit/bin/activate
-```
-
 You can create an environment for development with `python3-venv`:
 
 ```bash
 sudo apt install python3-venv
 python3 -m venv venv
+source venv/bin/activate
+pip install tox
 ```
 
 Install `tox` inside the virtual environment for testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,8 @@ The code for this charm can be downloaded as follows:
 git clone https://github.com/canonical/<charm-name>
 ```
 
-You can create an environment for development with `python3-venv`:
+You can create an environment for development with `python3-venv`.
+We will also install `tox` inside the virtual environment for testing:
 
 ```bash
 sudo apt install python3-venv
@@ -123,8 +124,6 @@ python3 -m venv venv
 source venv/bin/activate
 pip install tox
 ```
-
-Install `tox` inside the virtual environment for testing.
 
 ### Test
 

--- a/docs-template/changelog.md
+++ b/docs-template/changelog.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Each revision is versioned by the date of the revision.

--- a/docs-template/changelog.md
+++ b/docs-template/changelog.md
@@ -1,7 +1,0 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-
-Each revision is versioned by the date of the revision.

--- a/docs-template/explanation/charm-architecture.md
+++ b/docs-template/explanation/charm-architecture.md
@@ -1,12 +1,12 @@
 # Charm architecture
 
 Add overview material here:
-1) What kind of application is it? What kind of software does it use?
-2) Describe Pebble services.
-3) Include an architecture diagram.
 
-<!-- Example: Indico
-At its core, [Indico](https://getindico.io/) is a [Flask](https://flask.palletsprojects.com/) application that integrates with [PostgreSQL](https://www.postgresql.org/), [Redis](https://redis.io/), and [Celery](https://docs.celeryq.dev/en/stable/).
+1. What kind of application is it? What kind of software does it use?
+2. Describe Pebble services.
+
+<!-- Example text
+At its core, the <charm-name> charm is <software> that does <brief description>.
 
 The charm design leverages the [sidecar](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers) pattern to allow multiple containers in each pod with [Pebble](https://juju.is/docs/sdk/pebble) running as the workload container’s entrypoint.
 
@@ -14,62 +14,75 @@ Pebble is a lightweight, API-driven process supervisor that is responsible for c
 
 Pebble `services` are configured through [layers](https://github.com/canonical/pebble#layer-specification), and the following containers represent each one a layer forming the effective Pebble configuration, or `plan`:
 
-1. An [NGINX](https://www.nginx.com/) container, which can be used to efficiently serve static resources, as well as be the incoming point for all web traffic to the pod.
-2. The [Indico](https://getindico.io/) container itself, which has a [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/) server configured in HTTP mode.
+1. Container 1, which does this and that.
+2. Container 2, which does that and this.
+3. And so on.
 
 
-As a result, if you run a `kubectl get pods` on a namespace named for the Juju model you've deployed the Indico charm into, you'll see something like the following:
+As a result, if you run a `kubectl get pods` on a namespace named for the Juju model you've deployed the <charm-name> charm into, you'll see something like the following:
 
 ```bash
 NAME                             READY   STATUS    RESTARTS   AGE
-indico-0                         3/3     Running   0         6h4m
+<charm-name>-0                   N/N     Running   0         6h4m
 ```
 
-This shows there are 4 containers - the three named above, as well as a container for the charm code itself.
-
-And if you run `kubectl describe pod indico-0`, all the containers will have as Command ```/charm/bin/pebble```. That's because Pebble is responsible for the processes startup as explained above.
+This shows there are <NUMBER> containers - <describe what the containers are>.
 -->
 
-## OCI images
+## High-level overview of <charm-name> deployment
 
-We use [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) to build OCI Images for <charm-name>. 
-The images are defined in [<charm-name> rock](link to rock).
-They are published to [Charmhub](https://charmhub.io/), the official repository of charms.
+The following diagram shows a typical deployment of the <charm-name> charm.
+<!-- 
+    Provide a brief description of the deployment here. Is it a Kubernetes cloud, a VM, or both?
+    What other charms are included in this deployment? 
+-->
 
-> See more: [How to publish your charm on Charmhub](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-charms/#publish-a-charm-on-charmhub)
+<!-- Include a Mermaid diagram of the charm deployment here. 
+     Use one container per charm; the point of this high-level overview is to show
+     a typical deployment and not provide a detailed breakdown of any of the charms.
+     Provide a brief description of the relations (for instance, "provides connection",
+     "caches storage", or "provides database").
+-->
 
-## (Optional) Containers
+## Charm architecture
 
-Configuration files for the containers can be found in the respective directories that define the rocks.
+The following diagram shows the architecture of the <charm-name> charm:
+
+<!-- Include a Mermaid diagram of the charm here. 
+     Limit the scope of this diagram to the charm only.
+     How is the charm containerized? Include those separate pieces in this diagram.
+-->
+
+### Containers
+
+Configuration files for the containers can be found in the respective directories that define the rock.
 
 <!--
-### Container example
+#### Container example
 
 Description of container.
 
 The workload that this container is running is defined in the [<container-name> rock](link to rock).
 -->
 
+## OCI images
+
+We use [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) to build OCI Images for <charm-name>.
+The images are defined in [<charm-name> rock](link to rock).
+They are published to [Charmhub](https://charmhub.io/), the official repository of charms.
+
+> See more: [How to publish your charm on Charmhub](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-charms/#publish-a-charm-on-charmhub)
+
 ## Metrics
-<!--
-Add a description of the metrics:
-* Are there metrics for containers, non-containerised workloads, snaps, or something else?
-* How are the metrics defined or added?
-* In what container is the metric run? What statistics or values does the metric provide? 
-* How is the container started? 
-* On what port(s) does the metric listen?
-
-For example, if the charm uses containers: Inside the above mentioned containers, additional Pebble layers are defined in order to provide metrics.
--->
 
 <!--
-### Metrics example
+If the charm uses metrics, include a list under reference/metrics.md and link that document here.
+If the charm uses containers, you may include text here like:
 
-Description of metric. 
-
-The workload that this container is running is defined in the [<container-name> rock](link to rock).
+Inside the above mentioned containers, additional Pebble layers are defined in order to provide metrics.
+See [metrics](link-to-metrics-document) for more information.
 -->
- 
+
 ## Juju events
 
 For this charm, the following Juju events are observed:
@@ -93,12 +106,16 @@ The `__init__` method guarantees that the charm observes all events relevant to 
 Take, for example, when a configuration is changed by using the CLI.
 
 1. User runs the configuration command:
+
 ```bash
 juju config <relevant-charm-configuration>
 ```
+
 2. A `config-changed` event is emitted.
 3. In the `__init__` method is defined how to handle this event like this:
+
 ```python
 self.framework.observe(self.on.config_changed, self._on_config_changed)
 ```
+
 4. The method `_on_config_changed`, for its turn, will take the necessary actions such as waiting for all the relations to be ready and then configuring the containers.

--- a/docs-template/explanation/security.md
+++ b/docs-template/explanation/security.md
@@ -1,0 +1,26 @@
+# Security overview
+
+<!-- Remember to update this file for your charm!!
+
+This document outlines the security design of the charm along common risks and
+possible best practices.
+
+Elaborate on topics such as common risks, good practices, built-in protection, etc.
+
+Are there upstream security docs that we can point to? If so, include a
+sentence like:
+For details regarding upstream <charm-name> configuration and broader security
+considerations, please refer to the [official <software> documentation](link-to-upstream-docs).
+
+## Risks
+In most cases, it will be appropriate to include a specific heading
+Risks under which known risks are listed and described. Include a subheading for best
+practices for the user to follow to avoid or limit risks.
+
+## Information security
+In some cases a product will have particular information security implications
+(concerned with potential for information loss, incorrect retention, unlawful disclosure
+and so on). Notes on these should be gathered separately in the overview topic, or
+in a topic of their own.
+
+-->

--- a/docs-template/how-to/back-up-restore.md
+++ b/docs-template/how-to/back-up-restore.md
@@ -1,0 +1,9 @@
+# How to back up and restore
+
+<!-- 
+    Remember to update this file for your charm!! 
+    If applicable, use this placeholder to provide information on how to
+    back up and restore the charm. Some questions to answer:
+    * Does this charm have a database that needs to be backed up?
+    * Are there are upstream docs we can link here?
+-->

--- a/docs-template/how-to/contribute.md
+++ b/docs-template/how-to/contribute.md
@@ -1,5 +1,15 @@
 # How to contribute
 
-<!-- TODO: Update the link to point to the correct repo!! -->
+<!-- TODO: Update the links to point to the correct repo!! -->
 
-See the [contributing guide](https://github.com/canonical/is-charms-template-repo/blob/main/CONTRIBUTING.md) on GitHub.
+Our documentation is hosted on the [Charmhub forum](link-to-charmhub-overview-page) to enable collaboration.
+Please use the "Help us improve this documentation" links on each documentation page to either
+directly change something you see that's wrong, ask a question, or make a suggestion about a potential
+change via the comments section.
+
+Our documentation is also available alongside the [source code on GitHub](link-to-github-repo).
+You may open a pull request with your documentation changes, or you can
+[file a bug](link-to-issues) to provide constructive feedback or suggestions.
+
+See [CONTRIBUTING.md](link-to-contributing-md)
+for information on contributing to the source code.

--- a/docs-template/how-to/integrate-with-cos.md
+++ b/docs-template/how-to/integrate-with-cos.md
@@ -1,0 +1,7 @@
+# Integrate with COS
+
+<!-- 
+    Remember to update this file for your charm!! 
+    If applicable, use this placeholder to provide information on how to
+    integrate the charm with COS. 
+-->

--- a/docs-template/how-to/upgrade.md
+++ b/docs-template/how-to/upgrade.md
@@ -1,0 +1,9 @@
+# How to upgrade
+
+<!-- 
+    Remember to update this file for your charm!! 
+    If applicable, use this placeholder to provide information on how to
+    upgrade the charm. Some questions to answer:
+    * Should we suggest that the user back up the charm before upgrading?
+    * Does the user need to reset any configurations? 
+-->

--- a/docs-template/how-to/upgrade.md
+++ b/docs-template/how-to/upgrade.md
@@ -4,6 +4,7 @@
     Remember to update this file for your charm!! 
     If applicable, use this placeholder to provide information on how to
     upgrade the charm. Some questions to answer:
-    * Should we suggest that the user back up the charm before upgrading?
+    * Should we suggest that the user back up the charm or its database
+      before upgrading?
     * Does the user need to reset any configurations? 
 -->

--- a/docs-template/index.md
+++ b/docs-template/index.md
@@ -27,12 +27,11 @@ This charm will make operating <charm-software> simple and straightforward for D
 
 ## Contributing to this documentation
 
-Documentation is an important part of this project, and we take the same open-source approach to the documentation as 
-the code. As such, we welcome community contributions, suggestions and constructive feedback on our documentation. 
-Our documentation is hosted on the [Charmhub forum](https://discourse.charmhub.io/) 
-to enable easy collaboration. Please use the "Help us improve this documentation" links on each documentation page to 
-either directly change something you see that's wrong, ask a question or make a suggestion about a potential change via 
-the comments section.
+Documentation is an important part of this project, and we take the same open-source approach
+to the documentation as the code. As such, we welcome community contributions, suggestions, and
+constructive feedback on our documentation.
+See [How to contribute](link to contribute page) for more information.
+
 
 If there's a particular area of documentation that you'd like to see that's missing, please 
 [file a bug](link to issues page).

--- a/docs-template/reference/metrics.md
+++ b/docs-template/reference/metrics.md
@@ -1,0 +1,17 @@
+## Metrics
+
+<!-- 
+Remember to update this file for your charm!! 
+If applicable, use this placeholder to include information on the alerting
+and monitoring metrics that exist for this charm. 
+
+List the metrics and include a brief explanation of each one
+(including units, if applicable). End each item with a period.
+
+EXAMPLE LIST:
+* **keys_added**: Number of new keys added since startup.
+* **keys_ignored**: Number of keys with no-op (unchanged) updates.
+* **keys_removed**: Number of keys removed since startup.
+* **http_request_duration_seconds**: Time spent generating HTTP responses.
+
+-->

--- a/docs-template/reference/metrics.md
+++ b/docs-template/reference/metrics.md
@@ -8,6 +8,13 @@ and monitoring metrics that exist for this charm.
 List the metrics and include a brief explanation of each one
 (including units, if applicable). End each item with a period.
 
+Add a description of the metrics:
+* Are there metrics for containers, non-containerised workloads, snaps, or something else?
+* How are the metrics defined or added?
+* In what container is the metric run? What statistics or values does the metric provide? 
+* How is the container started? 
+* On what port(s) does the metric listen?
+
 EXAMPLE LIST:
 * **keys_added**: Number of new keys added since startup.
 * **keys_ignored**: Number of keys with no-op (unchanged) updates.


### PR DESCRIPTION
### Overview

Iterate on template documentation and add placeholder files for common documentation.

### Rationale

* Added placeholder how-to documents for upgrading, backing up and restoring, and integrating with COS.
* Added placeholder reference document for metrics.
* Added placeholder explanation document for security overview.
* Updated the contributing documentation based on feedback from the contributing documentation for the WordPress and Discourse charms.
* Updated the charm architecture document based on feedback across several charms. Specifically, included a dedicated section for a high-level overview diagram.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
There's no documentation or changelog for this repo.
