### PR TITLE
feat: Adding pythonpath to pytest options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ disable = "wrong-import-order"
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+pythonpath = [
+  "lib",
+  "src"
+]
 
 # Linting tools configuration
 [tool.ruff]


### PR DESCRIPTION
### Overview

Adding pythonpath in `pyproject.toml` to include `lib` and `src` directories for pytest

### Rationale

Adding this path enables VSCode users to run and debug unit tests and Jubilant tests in the IDE. This helps massively while debugging the code.

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
