### PR TITLE
Feat/sync jira issues

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,16 @@
+# See https://github.com/canonical/gh-jira-sync-bot for advanced config
+settings:
+  jira_project_key: "ISD"
+  
+  status_mapping:
+    opened: Untriaged
+    closed: done
+    not_planned: rejected
+    
+  add_gh_comment: true
+  
+  epic_key: ISD-3981
+      
+  label_mapping:
+    bug: Bug
+    enhancement: Story

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-labels: ["Type: Bug", "Status: Triage"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,6 +1,6 @@
 name: Enhancement Proposal
 description: File an enhancement proposal
-labels: ["Type: Enhancement", "Status: Triage"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Applicable spec: https://warthogs.atlassian.net/browse/ISD-2850

### Overview

All new issues on the repositories will trigger the creation of a ticket in Jira.

A comment will be sent back to the user to reflect the creation of the Jira issue.

### Rationale

We plan our work based on Jira. Having all issues created there helps ensuring we cover all requests.