### PR TITLE
Update relative path in release-template.md.j2

### DIFF
--- a/docs-template/release-notes/template/release-template.md.j2
+++ b/docs-template/release-notes/template/release-template.md.j2
@@ -28,7 +28,7 @@ Main bug fixes:
 {% endif -%}
 {% endfor %}
 
-See our [Release policy and schedule](docs/release-notes/landing-page.md).
+See our [Release policy and schedule](landing-page.md).
 
 ## Requirements and compatibility
 


### PR DESCRIPTION
### Overview

Fixes https://github.com/canonical/platform-engineering-charm-template/issues/71

### Rationale

Linkchecker is failing, so the relative path for the release notes landing page needs to be updated.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
